### PR TITLE
Refactor Content Type, Filename and Content Disposition handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     activestorage-openstack (0.1.0)
       fog-openstack
+      marcel
       mime-types
 
 GEM
@@ -59,11 +60,11 @@ GEM
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
+    fog-json (1.2.0)
+      fog-core
       multi_json (~> 1.10)
-    fog-openstack (0.1.25)
-      fog-core (~> 1.40)
+    fog-openstack (0.1.27)
+      fog-core (~> 1.45.0)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
     formatador (0.2.5)
@@ -144,4 +145,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ the `openstack_temp_url_key` in your configuration is mandatory for generating U
 
 The next version of this plugin, will add a rails generator, or expose a method that would use the built-in method from `Fog::OpenStack::Real` to generate the key.
 
+## `ActiveStorage::Openstack`'s Content-Type handling
+
+OpenStack Swift handles the Content-Type of an object differently from other object storage services. You cannot overwrite the Content-Type via a temp URL. This gem will try very hard to set the right Content-Type for an object at object creation (eigther via server upload or direct upload) but this is wrong in edge cases (e.g. you use direct upload and the browser provides a wrong mime type).
+
+For this edge cases `ActiveStorage::Blob::Identifiable` downloads the first 4K of a file, identifies the content type and saves the result in the database. For `ActiveStorage::Openstack` we also need to update the Content-Type of the object. This is done automatically with a little monkey patch.
+
 ## Testing
 First, run `bundle` to install the gem dependencies (both development and production)
 ```bash

--- a/activestorage-openstack.gemspec
+++ b/activestorage-openstack.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
  s.add_dependency "fog-openstack"
  s.add_dependency "mime-types"
+ s.add_dependency "marcel"
 
 
   s.add_development_dependency "sqlite3"

--- a/lib/active_storage/openstack.rb
+++ b/lib/active_storage/openstack.rb
@@ -1,7 +1,0 @@
-require "active_storage/openstack/railtie"
-
-module ActiveStorage
-  module Openstack
-    # Your code goes here...
-  end
-end

--- a/lib/active_storage/openstack/railtie.rb
+++ b/lib/active_storage/openstack/railtie.rb
@@ -1,6 +1,18 @@
 module ActiveStorage
   module Openstack
     class Railtie < ::Rails::Railtie
+      initializer "active_storage_openstack.blob" do
+        ActiveSupport.on_load(:active_storage_blob) do |klass|
+          klass.after_commit do |blob|
+            # overwrite conten type if identification ran and 
+            # the service responds to change_content_type 
+            if blob.identified? && !blob.content_type.blank? && 
+               blob.service.respond_to?(:change_content_type)
+              blob.service.change_content_type(blob.key, blob.content_type)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/activestorage-openstack.rb
+++ b/lib/activestorage-openstack.rb
@@ -1,0 +1,2 @@
+require "active_storage/openstack/version"
+require "active_storage/openstack/railtie"

--- a/test/active_storage/service/open_stack_service_test.rb
+++ b/test/active_storage/service/open_stack_service_test.rb
@@ -52,6 +52,13 @@ if SERVICE_CONFIGURATIONS[:openstack]
       assert_equal FIXTURE_DATA, @service.download(FIXTURE_KEY)
     end
 
+    test "correct metadata" do
+      url = @service.url(FIXTURE_KEY, expires_in: 5.minutes,
+                           disposition: :inline,
+                           filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+      asset_metadata url, content_type: "image/png", content_length: FIXTURE_DATA.bytesize, filename: "avatar.png", disposition: "inline"
+    end
+
     test "downloading in chunks" do
       key = SecureRandom.base58(24)
       chunk_size = @service.client.instance_values["connection_options"][:chunk_size] || 1.megabyte # default for OpenStack
@@ -82,6 +89,8 @@ if SERVICE_CONFIGURATIONS[:openstack]
                                       filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
 
       assert_match SERVICE_CONFIGURATIONS[:openstack][:container], url
+      assert_match "avatar.png", url
+      assert_match "inline", url
     end
 
     test "direct upload" do
@@ -89,25 +98,35 @@ if SERVICE_CONFIGURATIONS[:openstack]
         key      = SecureRandom.base58(24)
         data     = "Something else entirely!"
         checksum = Digest::MD5.base64digest(data)
-        hex_checksum = Digest::MD5.hexdigest(data) # For OpenStack
 
         url = @service.url_for_direct_upload(key,
                                              expires_in: 5.minutes,
                                              content_type: "text/plain",
-                                             content_length: data.size,
+                                             content_length: data.bytesize,
                                              checksum: checksum)
+        headers = @service.headers_for_direct_upload(key, 
+                                                     filename: ActiveStorage::Filename.new("something.txt"),
+                                                     content_type: "text/plain",
+                                                     content_length: data.bytesize,
+                                                     checksum: checksum)
 
         uri = URI.parse url
         request = Net::HTTP::Put.new uri.request_uri
         request.body = data
-        request.add_field "Content-Type", "text/plain"
-        request.add_field "Etag", hex_checksum
-        request.add_field "Content-Length", data.size
+        request.add_field "Content-Length", data.bytesize
+        headers.each_pair do |key, val|
+          request.add_field key, val
+        end
         Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
           http.request request
         end
 
         assert_equal data, @service.download(key)
+
+        url = @service.url(key, expires_in: 5.minutes,
+                           disposition: :attachment,
+                           filename: ActiveStorage::Filename.new("something.txt"), content_type: "text/plain")
+        asset_metadata url, content_type: "text/plain", content_length: data.bytesize, filename: "something.txt", disposition: "attachment"
       ensure
         @service.delete key
       end
@@ -143,6 +162,36 @@ if SERVICE_CONFIGURATIONS[:openstack]
         @service.delete("a/a/a")
         @service.delete("a/a/b")
         @service.delete("a/b/a")
+      end
+    end
+
+    test "change_content_type" do
+      key = SecureRandom.base58(24)
+      begin
+        @service.upload(key, StringIO.new(FIXTURE_DATA))
+        @service.change_content_type(key, "text/plain")
+        url = @service.url(key, expires_in: 5.minutes,
+                           disposition: :attachment,
+                           filename: ActiveStorage::Filename.new("something.txt"))
+        asset_metadata url, content_type: "text/plain"
+        @service.change_content_type(key, "application/octet-stream")
+        url = @service.url(key, expires_in: 5.minutes,
+                           disposition: :attachment,
+                           filename: ActiveStorage::Filename.new("something.txt"))
+        asset_metadata url, content_type: "application/octet-stream"
+      ensure
+        @service.delete(key)
+      end
+    end
+
+    def asset_metadata url, content_type: nil, content_length: nil, filename: nil, disposition: nil
+      uri = URI.parse url
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        response = http.head uri.request_uri
+        assert_equal content_type.to_s, response['content-type'] unless content_type.nil?
+        assert_equal content_length.to_s, response['content-length'] unless content_length.nil?
+        assert_match filename.to_s, response['content-disposition'] unless filename.nil?
+        assert_match disposition.to_s, response['content-disposition'] unless disposition.nil?
       end
     end
   end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -3,7 +3,7 @@ require_relative 'boot'
 require 'rails/all'
 
 Bundler.require(*Rails.groups)
-require "active_storage/openstack"
+require "activestorage-openstack"
 
 module Dummy
   class Application < Rails::Application


### PR DESCRIPTION
* Fix `headers_for_direct_upload`: The filename parameter was missing for headers_for_direct_upload. This prevented direct upload from working
* Fix `headers_for_direct_upload`: The Content-Length header is redundant and e.g. Chrome does not allow to set this header anyways.
* Fix `url`: The url method used Fog::Storage::OpenStack.get_object_https_url wrongly
* Change `upload`: set the initial content type of the object as a best guess.
* Add `change_content_type`: Add method to change the content type of an existing object.
* Add Rails initializer that hooks the change_content_type method up
* Add the default entry point (`activestorage-openstack.rb`) so that our Railtie gets loaded
* Add some tests