### PR TITLE
Compute a checksum dynamically in #upload

### DIFF
--- a/test/active_storage/service/open_stack_service_test.rb
+++ b/test/active_storage/service/open_stack_service_test.rb
@@ -48,6 +48,21 @@ if SERVICE_CONFIGURATIONS[:openstack]
       end
     end
 
+    test "Computing automatically a checksum on #upload when no checksum is provided" do
+      begin
+        key  = SecureRandom.base58(24)
+        data = "Some random string!"
+        expected_checksum = Digest::MD5.hexdigest(data)
+
+        response = @service.upload(key, StringIO.new(data))
+
+        assert_equal data, @service.download(key)
+        assert_equal expected_checksum, response.headers["ETag"]
+      ensure
+        @service.delete key
+      end
+    end
+
     test "downloading" do
       assert_equal FIXTURE_DATA, @service.download(FIXTURE_KEY)
     end


### PR DESCRIPTION
When uploading a variant, rails does not send a checksum. For this case,
we compute the checksum from the io by returning a MD5 hexdigest, then
send it as a `ETag` request header, so that we always validate and
enforce integrity, whether it be a regular file upload, or a variant file upload.