### PR TITLE
Handle fog-openstack 0.x and 1.0 storage class names

### DIFF
--- a/activestorage-openstack.gemspec
+++ b/activestorage-openstack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "fog-openstack", '~> 0.3'
+  s.add_dependency "fog-openstack", '< 2.0'
   s.add_dependency "marcel"
   s.add_dependency "mime-types"
   s.add_dependency "rails", "~> 5.2.0"

--- a/lib/active_storage/service/open_stack_service.rb
+++ b/lib/active_storage/service/open_stack_service.rb
@@ -7,7 +7,13 @@ module ActiveStorage
     def initialize(container:, credentials:, connection_options: {})
       settings = credentials.reverse_merge(connection_options: connection_options)
 
-      @client = Fog::OpenStack::Storage.new(settings)
+      fog_openstack_storage_class = if defined?(Fog::OpenStack::Storage)
+        Fog::OpenStack::Storage
+      else
+        Fog::Storage::OpenStack
+      end
+
+      @client = fog_openstack_storage_class.new(settings)
       @container = Fog::OpenStack.escape(container)
     end
 


### PR DESCRIPTION
This PR makes the gem compatible with the current fog-openstack 1.0 lib. 

It's a simple if/else that check for the existence of the `Fog::Openstack::Storage` class and uses it instead of `Fog::Storage::Openstack` when creating the client instance.

I also raised the gemspec's fog-openstack version limit to `< 2.0`