### PR TITLE
Revamp plugin.This fixes #33

### DIFF
--- a/lib/active_storage/openstack/railtie.rb
+++ b/lib/active_storage/openstack/railtie.rb
@@ -1,18 +1,6 @@
 module ActiveStorage
   module Openstack
     class Railtie < ::Rails::Railtie
-      initializer "active_storage_openstack.blob" do
-        ActiveSupport.on_load(:active_storage_blob) do |klass|
-          klass.after_commit do |blob|
-            # overwrite content type if identification run and
-            # the service responds to change_content_type
-            if blob.identified? && !blob.content_type.blank? &&
-               blob.service.respond_to?(:change_content_type)
-              blob.service.change_content_type(blob.key, blob.content_type)
-            end
-          end
-        end
-      end
     end
   end
 end

--- a/lib/active_storage/service/open_stack_service.rb
+++ b/lib/active_storage/service/open_stack_service.rb
@@ -11,10 +11,14 @@ module ActiveStorage
       @container = Fog::OpenStack.escape(container)
     end
 
-    def upload(key, io, checksum: nil, **)
+    def upload(key, io, checksum: nil, disposition: nil, content_type: nil, filename: nil, **)
       instrument :upload, key: key, checksum: checksum do
-        params = { 'Content-Type' => guess_content_type(io) }
+        params = { 'Content-Type' => content_type || guess_content_type(io) }
         params['ETag'] = convert_base64digest_to_hexdigest(checksum) if checksum
+        if disposition && filename
+          params['Content-Disposition'] =
+            content_disposition_with(type: disposition, filename: filename)
+        end
 
         begin
           client.put_object(container, key, io, params)
@@ -51,13 +55,12 @@ module ActiveStorage
         raise ActiveStorage::FileNotFoundError if defined?(ActiveStorage::FileNotFoundError)
       end
     end
+
     def delete(key)
       instrument :delete, key: key do
-        begin
-          client.delete_object(container, key)
-        rescue Fog::OpenStack::Storage::NotFound
-          false
-        end
+        client.delete_object(container, key)
+      rescue Fog::OpenStack::Storage::NotFound
+        false
       end
     end
 
@@ -73,12 +76,10 @@ module ActiveStorage
 
     def exist?(key)
       instrument :exist, key: key do |payload|
-        begin
-          answer = object_for(key)
-          payload[:exist] = answer.present?
-        rescue Fog::OpenStack::Storage::NotFound
-          payload[:exist] = false
-        end
+        answer = object_for(key)
+        payload[:exist] = answer.present?
+      rescue Fog::OpenStack::Storage::NotFound
+        payload[:exist] = false
       end
     end
 
@@ -91,7 +92,7 @@ module ActiveStorage
             key,
             expire_at,
             filename: filename
-        )
+          )
         generated_url += '&inline' if disposition.to_s != 'attachment'
         # unfortunately OpenStack Swift cannot overwrite the content type of an object via a temp url
         # so we just ignore the content_type argument here
@@ -124,14 +125,20 @@ module ActiveStorage
       }
     end
 
-    # Non-standard method to change the content type of an existing object
-    def change_content_type(key, content_type)
-      client.post_object(container,
-                         key,
-                         'Content-Type' => content_type)
-      true
-    rescue Fog::OpenStack::Storage::NotFound
-      raise ActiveStorage::FileNotFoundError if defined?(ActiveStorage::FileNotFoundError)
+    def update_metadata(key, content_type:, disposition: nil, filename: nil, **)
+      instrument :update_metadata, key: key, content_type: content_type, disposition: disposition do
+        params = { 'Content-Type' => content_type }
+        if disposition && filename
+          params['Content-Disposition'] =
+            content_disposition_with(type: disposition, filename: ActiveStorage::Filename.new(filename))
+        end
+        client.post_object(container,
+                           key,
+                           params)
+        true
+      rescue Fog::OpenStack::Storage::NotFound
+        raise ActiveStorage::FileNotFoundError if defined?(ActiveStorage::FileNotFoundError)
+      end
     end
 
   private
@@ -143,7 +150,7 @@ module ActiveStorage
     # ActiveStorage sends a `Digest::MD5.base64digest` checksum
     # OpenStack expects a `Digest::MD5.hexdigest` ETag
     def convert_base64digest_to_hexdigest(base64digest)
-      base64digest.unpack('m0').first.unpack('H*').first
+      base64digest.unpack1('m0').unpack1('H*')
     end
 
     def unix_timestamp_expires_at(seconds_from_now)


### PR DESCRIPTION
Rails 6.0.1 now aliases `create_after_upload` to `create_and_upload`
forcing the creation of the blob before uplaoding to the blob provider.
This causes a bug with this plugin since we add a after_commit hook
when a blob is created that updates the metadata(content type) of the
blob on the openstack provider assuming the blob had already
been uploaded beforehand.
An `ActiveStorage::FileNotFound` error is then raised because it tries
to update the metadata of a file that does not exist yet.

This hook is now totally removed. However for versions that are inferior
to rails 6.0.1, and starting from `5.2.1.1`, Rails has added native
support for a method called `update_metadata` that calls the service and
tries to update the blob in case it has not been identified yet.
To make this plugin work for all versions, the `update_metadata` method
has been implemetend replacing the current non standard method
"change_content_type".
Aliasing the old method to the newer one and deprecating the old method
won't work since the method signatures are not the same. Plus it was
used as a hack/non standard method workaround.

Misc changes:
- Rubocop cleanup + test updates.
- Content type is now only guessed if rails does not send it as a meta
parameter. However guessing content type inside the provider class is
unnecessary starting from version 5.2.1.1.
Will consider removing this altogether in a future release
- Update tests accordingly.
- Send Content-Disposition header in #upload definition if filename and
disposition are passed as params. 

Issue: #33 